### PR TITLE
Add correct port to starting log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import app from './app.js';
+const port = process.env.PORT || 5000;
 
-app.listen(process.env.PORT || 5000, () => {
+app.listen(port, () => {
   console.clear();
-  console.info(`API Running on: 5000 ============================`);
+  console.info(`API Running on: ${port} ============================`);
 });


### PR DESCRIPTION
This prints the current listening port in the case it is a non default one