### PR TITLE
Fixed typo in '/latest' endpoint

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -1,6 +1,6 @@
 ## Endpoints
 
-> PATH: /lastest
+> PATH: /latest
 
 |Querys|Params|
 |-|-|

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,6 +1,6 @@
 export * from './all'
 export * from './anime'
-export * from './lastest'
+export * from './latest'
 export * from './calendar'
 export * from './emision'
 export * from './search'

--- a/src/controllers/latest.ts
+++ b/src/controllers/latest.ts
@@ -1,7 +1,7 @@
 import { Controller } from '../types'
 import { get, parse, attr, url } from '../api'
 
-export const getLastest: Controller = async (req, res) => {
+export const getLatest: Controller = async (req, res) => {
   try {
     const { data } = await get(url)
     const html = parse(data)

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import {
   getAll,
-  getLastest,
+  getLatest,
   getCalendar,
   getEmision,
   getAnime,
@@ -18,7 +18,7 @@ routes.get('/', (_, res) => {
     author: 'Carlos Burelo',
     repository: 'https://github.com/carlos-burelo/monoschinos-api-v2',
     endpoints: {
-      lastest: '/lastest',
+      latest: '/latest',
       emision: '/emision',
       calendar: '/week',
       getAnimeByID: '/anime/:id',
@@ -34,7 +34,7 @@ routes.get('/', (_, res) => {
 })
 
 routes.get('/all', getAll)
-routes.get('/lastest', getLastest)
+routes.get(['/lastest', '/latest'], getLatest)
 routes.get('/week', getCalendar)
 routes.get('/emision', getEmision)
 routes.get('/anime/:id', getAnime)

--- a/src/router.ts
+++ b/src/router.ts
@@ -22,12 +22,12 @@ routes.get('/', (_, res) => {
       emision: '/emision',
       calendar: '/week',
       getAnimeByID: '/anime/:id',
-      getAnimesByPage: '/all',
+      getAnimeByPage: '/all',
       getEpisodeByID: '/ver/:id',
       searchAnimeByID: '/search/:id',
       filterBy: {
         path: '/filterBy',
-        querys: ['categoria', 'fecha', 'genero', 'letra', 'pagina'],
+        query: ['categoria', 'fecha', 'genero', 'letra', 'pagina'],
       },
     },
   })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 
 export type Controller = (req: Request, res: Response) => void
 
-export interface Lastest {
+export interface Latest {
   id: string
   title: string
   image: string


### PR DESCRIPTION
It also maintains compatibility with old call
Should be a straightforward change with no incompatibilities.