### PR TITLE
Fix /latest episode chapter number parser

### DIFF
--- a/src/controllers/latest.ts
+++ b/src/controllers/latest.ts
@@ -13,7 +13,7 @@ export const getLatest: Controller = async (req, res) => {
           title: i.querySelector('.animetitles')?.text || null,
           image: attr(i, '.animeimgdiv img', 'data-src') || null,
           type: i.querySelector('.positioning button')?.text.trim() || null,
-          no: parseInt(i.querySelector('.positioning h5')?.text.trim() || '0') || null,
+          no: parseInt(i.querySelector('.positioning p')?.text.trim() || '0') || null,
         }
       })
     )


### PR DESCRIPTION
Web changed the html element containing the number from `h5` to `p`

I didn't search for any more changes as this is the only part that needed a quick fix.