### PR TITLE
Fix image selector, fixes "image": null

### DIFF
--- a/src/controllers/latest.ts
+++ b/src/controllers/latest.ts
@@ -10,7 +10,7 @@ export const getLatest: Controller = async (_, res) => {
         return {
           id: id || null,
           title: i.querySelector('.animetitles')?.text || null,
-          image: attr(i, '.animeimgdiv img', 'data-src') || null,
+          image: attr(i, 'img.animeimghv', 'src') || null,
           type: i.querySelector('.positioning button')?.text.trim() || null,
           no: parseInt(i.querySelector('.positioning p')?.text.trim() || '0') || null,
         }


### PR DESCRIPTION
Changed the css selector of the image attribute
gets the URL again now
haven't tested anything, just a quick fix